### PR TITLE
security: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
-      - uses: gradle/gradle-build-action@v2.7.1
+      - uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
       - name: Make Gradle executable
         run: chmod +x ./gradlew
       - name: Run unit tests
@@ -56,7 +56,7 @@ jobs:
           distribution: zulu
           java-version: 17
 
-      - uses: gradle/gradle-build-action@v2.7.1
+      - uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
       - name: Make Gradle executable
         run: chmod +x ./gradlew
 


### PR DESCRIPTION
## Summary
- Pin all `uses:` references in GitHub Actions workflows to full SHA hashes
- Prevents supply chain attacks via tag mutation or typosquatting

## Context
- https://rosesecurity.dev/2026/03/20/typosquatting-trivy.html
- Generated with [`pinact`](https://github.com/suzuki-shunsuke/pinact)

## Test plan
- [ ] Verify CI passes with pinned references
- [ ] Spot-check that pinned SHAs match expected release tags